### PR TITLE
Fixed previous button pagination logic.

### DIFF
--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -46,8 +46,8 @@ const Pagination = ({ index: currentPageIndex, totalPages }) => {
       {currentPageIndex !== 0 ? (
         <Link
           css={itemStyles}
-					to={prevPageNumber > 1 ? `/page-${prevPageNumber}` : `/`}
-				>
+          to={prevPageNumber > 1 ? `/page-${prevPageNumber}` : `/`}
+        >
           Previous
         </Link>
       ) : null}

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -46,8 +46,8 @@ const Pagination = ({ index: currentPageIndex, totalPages }) => {
       {currentPageIndex !== 0 ? (
         <Link
           css={itemStyles}
-          to={prevPageNumber === 0 ? '/' : `/page-${prevPageNumber}`}
-        >
+					to={prevPageNumber > 1 ? `/page-${prevPageNumber}` : `/`}
+				>
           Previous
         </Link>
       ) : null}


### PR DESCRIPTION
Love the new blog. 
While working with the source I noticed the previous pagination button, if the previous page was `/` would be set to the non-existent `/page-1`. I think this fixes the logic. 