### PR TITLE
Fix typo in function updaters post

### DIFF
--- a/src/posts/published/prefer-function-updaters-in-state-setters/index.mdx
+++ b/src/posts/published/prefer-function-updaters-in-state-setters/index.mdx
@@ -314,4 +314,4 @@ Now `useItemSelection` is a bit more flexible. Perhaps you want to use `name` as
 const [state, handlers] = useItemSelection(x => x?.name)
 ```
 
-No longer does `useItemSelection` for your data into a shape. You can easily conform `useItemSelection` to your data.
+No longer does `useItemSelection` force your data into a shape. You can easily conform `useItemSelection` to your data.


### PR DESCRIPTION
The post about `Prefer Function Updaters in State Setters` (https://kyleshevlin.com/prefer-function-updaters-in-state-setters) contains a typo: `for` should be `force`.