### PR TITLE
Change `===` to `=`

### DIFF
--- a/src/posts/published/dependency-injection-and-default-parameters/index.mdx
+++ b/src/posts/published/dependency-injection-and-default-parameters/index.mdx
@@ -184,7 +184,7 @@ function counts(items, getKey = identity) {
     const key = getKey(item, index, items)
 
     if (result[key] === undefined) {
-      result[key] === 0
+      result[key] = 0
     }
 
     result[key]++


### PR DESCRIPTION
Because the example is example is broken.