### PR TITLE
Fix link to the website in RSS feed

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -104,6 +104,7 @@ module.exports = {
                 title
                 description
                 siteUrl
+                site_url: siteUrl
               }
             }
           }


### PR DESCRIPTION
Currently there the link to the website in [the RSS feed](https://kyleshevlin.com/rss.xml) leads to `http://github.com/dylang/node-rss`. This is how feed looks like in Feedly, when trying to add the blog:

<img width="628" alt="CleanShot 2023-10-13 at 20 16 13" src="https://github.com/kyleshevlin/blog/assets/654597/96b37b3a-8982-4db4-a451-44c77a80d810">

I did not test this change (I'm not familiar with Gatsby and don't want to spend much time on it). But I believe it is correct change according to example in [`gatsby-plugin-feed` docs](https://www.gatsbyjs.com/plugins/gatsby-plugin-feed/) and [this comment](https://github.com/gatsbyjs/gatsby/issues/27476#issuecomment-709353591) with related issue.